### PR TITLE
poprawiona funkcja getRateBefore

### DIFF
--- a/src/MaciejSz/NbpPhp/NbpRepository.php
+++ b/src/MaciejSz/NbpPhp/NbpRepository.php
@@ -84,6 +84,10 @@ class NbpRepository
             }
         }
 
+        if ( null !== $prev ) {
+            return $prev;
+        }
+
         throw new Exc\ENbpEntryNotFound();
     }
 


### PR DESCRIPTION
Bez tej poprawki dostawałem błąd:

```
ENbpEntryNotFound in NbpRepository.php line 87:
in NbpRepository.php line 87
at NbpRepository->getFileNameBefore('2015-07-30') in NbpRepository.php line 141
at NbpRepository->getRatesBefore('2015-07-30') in NbpRepository.php line 169
at NbpRepository->getRateBefore('2015-07-30', 'HKD') in CurrencyController.php line 19
```
